### PR TITLE
Sync origin version develop branch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
         release {
             minifyEnabled false
             zipAlignEnabled true
-            shrinkResources true
+            shrinkResources false
 
             signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
disable shrinkResources because I think some res add by @simonla (xml/launcher_menu) was shrinked in release build. It causes build failure. to fix it, I have referred to https://developer.android.com/studio/build/shrink-code.html but it didn't work...
